### PR TITLE
Updating gradle and other dependencies.

### DIFF
--- a/notepad/app/build.gradle
+++ b/notepad/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.example.android.notepad"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,12 +21,13 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:26.0.2'
+    api 'com.android.support:appcompat-v7:27.1.1'
 
     // Firebase instrumentation lib
-    androidTestCompile 'com.google.firebase:testlab-instr-lib:0.1'
+    androidTestImplementation 'com.google.firebase:testlab-instr-lib:0.1'
 
     // Espresso testing
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
-    androidTestCompile 'com.android.support:support-annotations:26.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }

--- a/notepad/build.gradle
+++ b/notepad/build.gradle
@@ -1,9 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.google.gms:google-services:3.3.0'
     }
 }
 

--- a/notepad/gradle/wrapper/gradle-wrapper.properties
+++ b/notepad/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 01 22:30:18 PDT 2017
+#Fri May 04 14:08:38 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Since the anouncement of sdk versioning in Google Play Services we can
now also include com.google.gms:google-services.

https://android-developers.googleblog.com/2018/05/announcing-new-sdk-versioning.html