### PR TITLE
Migrating notepad example app to AndroidX

### DIFF
--- a/notepad/app/build.gradle
+++ b/notepad/app/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         applicationId "com.example.android.notepad"
         minSdkVersion 15
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -21,13 +21,14 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // Firebase instrumentation lib
     androidTestImplementation 'com.google.firebase:testlab-instr-lib:0.1'
 
     // Espresso testing
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.annotation:annotation:1.0.0'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation('androidx.test:runner:1.1.0')
 }

--- a/notepad/app/src/androidTest/AndroidManifest.xml
+++ b/notepad/app/src/androidTest/AndroidManifest.xml
@@ -6,7 +6,7 @@
         <uses-library android:name="android.test.runner" />
     </application>
     <instrumentation
-        android:name="android.support.test.runner.AndroidJUnitRunner"
+        android:name="androidx.test.runner.AndroidJUnitRunner"
         android:targetPackage="com.example.android.notepad">
         <meta-data
             android:name="screenCaptureProcessors"

--- a/notepad/app/src/androidTest/java/com/example/android/notepad/NotePadTest.java
+++ b/notepad/app/src/androidTest/java/com/example/android/notepad/NotePadTest.java
@@ -16,10 +16,12 @@
 
 package com.example.android.notepad;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.support.test.runner.screenshot.Screenshot;
+import android.Manifest;
+import androidx.test.filters.SmallTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+import androidx.test.runner.screenshot.Screenshot;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,19 +29,19 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static android.support.test.espresso.Espresso.closeSoftKeyboard;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
-import static android.support.test.espresso.Espresso.pressBack;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.typeTextIntoFocusedView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.Espresso.closeSoftKeyboard;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.typeTextIntoFocusedView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasFocus;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -47,10 +49,13 @@ import static org.hamcrest.Matchers.allOf;
 public class NotePadTest {
 
     @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @Rule
     public ActivityTestRule<NotesList> activityRule = new ActivityTestRule<>(NotesList.class);
 
     @Test
-    public void testAddNote() throws InterruptedException, IOException {
+    public void testAddNote() throws IOException {
         // Take a screenshot when app becomes visible.
         onView(isRoot());
         Screenshot.capture().process();

--- a/notepad/app/src/main/AndroidManifest.xml
+++ b/notepad/app/src/main/AndroidManifest.xml
@@ -37,13 +37,13 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:scheme="http">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <action android:name="android.intent.action.PICK" />
 
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="vnd.android.cursor.dir/vnd.google.note" />
+                <data android:scheme="content" android:mimeType="vnd.android.cursor.dir/vnd.google.note" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.GET_CONTENT" />
@@ -55,16 +55,15 @@
         <activity
             android:name="NoteEditor"
             android:configChanges="keyboardHidden|orientation"
-            android:theme="@android:style/Theme.Light">
+            android:theme="@style/Theme.AppCompat.Light">
             <!-- This filter says that we can view or edit the data of
                  a single note -->
             <intent-filter android:label="@string/resolve_edit">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <action android:name="com.android.notes.action.EDIT_NOTE" />
-
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="vnd.android.cursor.item/vnd.google.note" />
+                <data android:scheme="content" android:mimeType="vnd.android.cursor.item/vnd.google.note" />
             </intent-filter>
 
             <!-- This filter says that we can create a new note inside
@@ -81,7 +80,7 @@
             android:name="TitleEditor"
             android:icon="@drawable/ic_menu_edit"
             android:label="@string/title_edit_title"
-            android:theme="@android:style/Theme.Dialog"
+            android:theme="@style/Theme.AppCompat.Dialog"
             android:windowSoftInputMode="stateVisible">
             <!-- This activity implements an alternative action that can be
                  performed on notes: editing their title.  It can be used as

--- a/notepad/app/src/main/java/com/example/android/notepad/NoteEditor.java
+++ b/notepad/app/src/main/java/com/example/android/notepad/NoteEditor.java
@@ -16,7 +16,6 @@
 
 package com.example.android.notepad;
 
-import android.app.Activity;
 import android.content.ComponentName;
 import android.content.ContentValues;
 import android.content.Context;
@@ -28,7 +27,6 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.InputType;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.Menu;
@@ -36,7 +34,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
 import android.widget.Toast;
-
+import androidx.appcompat.app.AppCompatActivity;
 import com.example.android.notepad.NotePad.NoteColumns;
 
 /**
@@ -44,7 +42,7 @@ import com.example.android.notepad.NotePad.NoteColumns;
  * either to simply view a note {@link android.content.Intent#ACTION_VIEW}, view and edit a note
  * {@link android.content.Intent#ACTION_EDIT}, or create a new note {@link android.content.Intent#ACTION_INSERT}.
  */
-public class NoteEditor extends Activity {
+public class NoteEditor extends AppCompatActivity {
     private static final String TAG = "NoteEditor";
 
     /**
@@ -76,7 +74,7 @@ public class NoteEditor extends Activity {
     /**
      * A custom EditText that draws lines between each line of text that is displayed.
      */
-    public static class LinedEditText extends EditText {
+    public static class LinedEditText extends androidx.appcompat.widget.AppCompatEditText {
         private Rect mRect;
         private Paint mPaint;
 
@@ -208,6 +206,7 @@ public class NoteEditor extends Activity {
     protected void onSaveInstanceState(Bundle outState) {
         // Save away the original text, so we still have it if the activity
         // needs to be killed while paused.
+        super.onSaveInstanceState(outState);
         outState.putString(ORIGINAL_CONTENT, mOriginalContent);
     }
 

--- a/notepad/app/src/main/java/com/example/android/notepad/NotesList.java
+++ b/notepad/app/src/main/java/com/example/android/notepad/NotesList.java
@@ -39,7 +39,7 @@ import com.example.android.notepad.NotePad.NoteColumns;
 /**
  * Displays a list of notes. Will display notes from the {@link android.net.Uri}
  * provided in the intent if there is one, otherwise defaults to displaying the
- * contents of the {@link NoteProvider}
+ * contents of the {@link NotePadProvider}
  */
 public class NotesList extends ListActivity {
     private static final String TAG = "NotesList";

--- a/notepad/app/src/main/java/com/example/android/notepad/NotesLiveFolder.java
+++ b/notepad/app/src/main/java/com/example/android/notepad/NotesLiveFolder.java
@@ -16,13 +16,13 @@
 
 package com.example.android.notepad;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.LiveFolders;
+import androidx.appcompat.app.AppCompatActivity;
 
-public class NotesLiveFolder extends Activity {
+public class NotesLiveFolder extends AppCompatActivity {
     /**
      * The URI for the Notes Live Folder content provider.
      */

--- a/notepad/app/src/main/java/com/example/android/notepad/TitleEditor.java
+++ b/notepad/app/src/main/java/com/example/android/notepad/TitleEditor.java
@@ -16,7 +16,6 @@
 
 package com.example.android.notepad;
 
-import android.app.Activity;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
@@ -24,14 +23,14 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
-
+import androidx.appcompat.app.AppCompatActivity;
 import com.example.android.notepad.NotePad.NoteColumns;
 
 /**
  * An activity that will edit the title of a note. Displays a floating
  * window with a text field.
  */
-public class TitleEditor extends Activity implements View.OnClickListener {
+public class TitleEditor extends AppCompatActivity implements View.OnClickListener {
 
     /**
      * This is a special intent action that means "edit the title of a note".

--- a/notepad/app/src/main/res/layout/note_editor.xml
+++ b/notepad/app/src/main/res/layout/note_editor.xml
@@ -24,4 +24,4 @@
     android:fadingEdge="vertical"
     android:gravity="top"
     android:textSize="22sp"
-    android:capitalize="sentences" />
+    android:inputType="textCapSentences" />

--- a/notepad/app/src/main/res/layout/noteslist_item.xml
+++ b/notepad/app/src/main/res/layout/noteslist_item.xml
@@ -17,9 +17,9 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@android:id/text1"
     android:layout_width="fill_parent"
-    android:layout_height="?android:attr/listPreferredItemHeight"
-    android:textAppearance="?android:attr/textAppearanceLarge"
-    android:gravity="center_vertical"
+    android:layout_height="wrap_content"
     android:paddingLeft="5dip"
+    android:paddingRight="5dip"
+    android:gravity="center_vertical"
     android:singleLine="true"
-/>
+    android:textAppearance="?android:attr/textAppearanceLarge" />

--- a/notepad/build.gradle
+++ b/notepad/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.google.gms:google-services:3.3.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.google.gms:google-services:4.3.8'
     }
 }
 

--- a/notepad/gradle.properties
+++ b/notepad/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/notepad/gradle/wrapper/gradle-wrapper.properties
+++ b/notepad/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
The notepad app for this project was still using android.support.test.

This migrates everything to AndroidX along with updating gradle and
other dependencies.